### PR TITLE
jsk_robot_utils: support multiple topics

### DIFF
--- a/jsk_robot_common/jsk_robot_utils/scripts/marker_msg_from_indigo_to_kinetic.py
+++ b/jsk_robot_common/jsk_robot_utils/scripts/marker_msg_from_indigo_to_kinetic.py
@@ -1,15 +1,81 @@
 #!/usr/bin/env python
-import rospy
-from visualization_msgs.msg import MarkerArray
+# -*- coding: utf-8 -*-
 
-def callback(data):
-    pub.publish(data)
-    
-def listener():
-    rospy.init_node('marker_msg_from_indigo_to_kinetic', anonymous=True)
-    rospy.Subscriber("spots_marker_array", rospy.AnyMsg, callback)
-    rospy.spin()
-        
+import os
+import rospy
+from visualization_msgs.msg import Marker, MarkerArray
+
+
+class VisualizationMarkerBridgeForKinetic(object):
+    def __init__(self):
+        if os.getenv("ROS_DISTRO", "kinetic") != "kinetic":
+            rospy.logwarn("This node works only on kinetic")
+
+        rate = rospy.get_param("~rate", 1.0)
+        self.suffix = rospy.get_param("~suffix", "kinetic")
+
+        self.publishers = dict()
+        self.subscribers = dict()
+
+        self.timer = rospy.Timer(rospy.Duration(rate), self.timer_cb)
+
+    def msg_cb(self, msg, name):
+        try:
+            self.publishers[name].publish(msg)
+            rospy.logdebug("Relayed %s" % name)
+        except Exception as e:
+            rospy.logerr(e)
+
+    def timer_cb(self, event=None):
+        all_topics = rospy.get_published_topics()
+        markers = [t[0] for t in all_topics if t[1] == "visualization_msgs/Marker" and\
+                   not t[0].endswith(self.suffix)]
+        arrays = [t[0] for t in all_topics if t[1] == "visualization_msgs/MarkerArray" and\
+                  not t[0].endswith(self.suffix)]
+        names = markers + arrays
+
+        for name in markers:
+            if name not in self.publishers:
+                new_name = name + "/" + self.suffix
+                self.publishers[name] = rospy.Publisher(
+                    new_name, Marker, queue_size=1)
+                rospy.logdebug("Advertised %s" % new_name)
+
+        for name in arrays:
+            if name not in self.publishers:
+                new_name = name + "/" + self.suffix
+                self.publishers[name] = rospy.Publisher(
+                    new_name, MarkerArray, queue_size=1)
+                rospy.logdebug("Advertised %s" % new_name)
+
+        for name, pub in self.publishers.items():
+            # clean old topics
+            if name not in names:
+                try:
+                    self.subscribers.pop(name).unregister()
+                    rospy.logdebug("Removed sub %s" % name)
+                except:
+                    pass
+                try:
+                    self.publishers.pop(name).unregister()
+                    rospy.logdebug("Removed pub %s" % name)
+                except:
+                    pass
+            # subscribe topics subscribed
+            elif pub.get_num_connections() > 0:
+                if name not in self.subscribers:
+                    self.subscribers[name] = rospy.Subscriber(
+                        name, rospy.AnyMsg,
+                        self.msg_cb, name)
+                    rospy.logdebug("Subscribed %s" % name)
+            # unsubscribe topics unsubscribed
+            else:
+                if name in self.subscribers:
+                    self.subscribers.pop(name).unregister()
+                    rospy.logdebug("Unsubscribed %s" % name)
+
+
 if __name__ == '__main__':
-    pub = rospy.Publisher('spots_marker_array_kinetic', MarkerArray, queue_size=10)
-    listener()
+    rospy.init_node("marker_msg_from_indigo_to_kinetic")
+    m = VisualizationMarkerBridgeForKinetic()
+    rospy.spin()


### PR DESCRIPTION
Relays marker topics from indigo to kinetic.
Topic names are remapped as follows:
- `foo_marker` -> `foo_marker/kinetic`
- `bar_marker_array` -> `bar_marker_array/kinetic`